### PR TITLE
Fix docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ _testmain.go
 *.prof
 peach.sublime-workspace
 peach.sublime-project
-peach
 custom*
 data
 /.idea

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -13,7 +13,7 @@ apk --no-cache --no-progress add --virtual build-deps go gcc musl-dev
 mkdir -p ${GOPATH}/src/github.com/peachdocs/
 ln -s /app/peach/ ${GOPATH}/src/github.com/peachdocs/peach
 cd ${GOPATH}/src/github.com/peachdocs/peach
-go get -v 
+go get -v
 mv ${GOPATH}/bin/peach .
 
 # Cleanup GOPATH

--- a/docker/s6/peach/run
+++ b/docker/s6/peach/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if test -f ./setup; then
+    source ./setup
+fi
+
+export USER=peach
+exec gosu $USER /app/peach/peach web

--- a/docker/s6/peach/setup
+++ b/docker/s6/peach/setup
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+cd /app/peach
+
+# Link volumed data with app data
+ln -sfn /data/peach/log  ./log
+ln -sfn /data/peach/custom ./custom
+
+chown -R peach:peach /data/peach /app/peach
+chmod 0755 /data /data/peach

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -9,7 +9,7 @@ create_socat_links() {
         elif echo $USED_PORT | grep -E "(^|:)$PORT($|:)" > /dev/null; then
             echo "init:socat  | Can't bind linked container ${NAME} to localhost, port ${PORT} already in use" 1>&2
         else
-            SERV_FOLDER=/app/gogs/docker/s6/SOCAT_${NAME}_${PORT}
+            SERV_FOLDER=/app/peach/docker/s6/SOCAT_${NAME}_${PORT}
             mkdir -p ${SERV_FOLDER}
             CMD="socat -ls TCP4-LISTEN:${PORT},fork,reuseaddr TCP4:${ADDR}:${PORT}"
             echo -e "#!/bin/sh\nexec $CMD" > ${SERV_FOLDER}/run


### PR DESCRIPTION
It seems `.gitignore` file also ignored `docker/s6/peach` leading to a
broken public docker image( #27). This commit fixes docker build scripts and
`.gitignore` file.