### PR TITLE
problem generating data/html files when using TargetDir

### DIFF
--- a/models/toc.go
+++ b/models/toc.go
@@ -122,7 +122,7 @@ func (n *Node) GenHTML(data []byte) error {
 	if setting.Docs.Type.IsLocal() {
 		htmlPath = path.Join(HTMLRoot, strings.TrimPrefix(n.FileName, setting.Docs.Target))
 	} else {
-		htmlPath = path.Join(HTMLRoot, strings.TrimPrefix(n.FileName, docsRoot))
+		htmlPath = path.Join(HTMLRoot, strings.TrimPrefix(n.FileName, path.Join(docsRoot, setting.Docs.TargetDir)))
 	}
 	htmlPath = strings.Replace(htmlPath, ".md", ".js", 1)
 

--- a/models/toc.go
+++ b/models/toc.go
@@ -122,7 +122,7 @@ func (n *Node) GenHTML(data []byte) error {
 	if setting.Docs.Type.IsLocal() {
 		htmlPath = path.Join(HTMLRoot, strings.TrimPrefix(n.FileName, setting.Docs.Target))
 	} else {
-		htmlPath = path.Join(HTMLRoot, strings.TrimPrefix(n.FileName, path.Join(docsRoot, setting.Docs.TargetDir)))
+		htmlPath = path.Join(HTMLRoot, strings.TrimPrefix(n.FileName, filepath.Join(docsRoot, setting.Docs.TargetDir)))
 	}
 	htmlPath = strings.Replace(htmlPath, ".md", ".js", 1)
 


### PR DESCRIPTION
Hello,  I'm having a problem using the TARGET_DIR setting.  It looks like GenHTML method in models/toc.go does not take the TargetDir setting into account.

**app.ini**:
```ini
[docs]
TARGET = https://github.com/jakup/peachdocs.git
TARGET_DIR = docs
```

**peach web output**:
```
[Macaron] 2019-05-22 20:59:50: Completed GET /en-US/intro/README.js?=1558573190 404 Not Found in 4.311266ms
[Macaron] 2019-05-22 20:59:50: Completed GET /en-US/intro/README.js?=1558573190 404 Not Found in 2.68745ms
```
**files are generated in data/html/{target_dir}/{lang}**:
```sh
# ls data/html/
docs
# ls data/html/docs/
en-US  zh-CN
```