### PR TITLE
setting to allow hiding of default NavBarItems

### DIFF
--- a/conf/app.ini
+++ b/conf/app.ini
@@ -32,6 +32,7 @@ ICON = github
 LOCALE = GitHub
 LINK = https://github.com/peachdocs/peach
 BLANK = true
+ENABLE = true
 
 [asset]
 CUSTOM_CSS = 

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -20,19 +20,21 @@ USE_CUSTOM_TPL = false
 -: github
 
 [navbar.home]
+ENABLED = true
 LOCALE = navbar.home
 LINK = /
 
 [navbar.documentation]
+ENABLED = true
 LOCALE = navbar.documentation
 LINK = /docs
 
 [navbar.github]
+ENABLED = true
 ICON = github
 LOCALE = GitHub
 LINK = https://github.com/peachdocs/peach
 BLANK = true
-ENABLE = true
 
 [asset]
 CUSTOM_CSS = 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -24,10 +24,10 @@ import (
 )
 
 type NavbarItem struct {
-	Icon         string
-	Locale, Link string
-	Blank        bool
-	Enable       bool
+	Icon          string
+	Locale, Link  string
+	Blank         bool
+	Enabled       bool
 }
 
 const (
@@ -166,7 +166,7 @@ func NewContext() {
 			Locale: Cfg.Section(secName).Key("LOCALE").MustString(secName),
 			Link:   Cfg.Section(secName).Key("LINK").MustString("/"),
 			Blank:  Cfg.Section(secName).Key("BLANK").MustBool(),
-			Enable: Cfg.Section(secName).Key("ENABLE").MustBool(true),
+			Enabled: Cfg.Section(secName).Key("ENABLED").MustBool(true),
 		}
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -27,6 +27,7 @@ type NavbarItem struct {
 	Icon         string
 	Locale, Link string
 	Blank        bool
+	Enable       bool
 }
 
 const (
@@ -165,6 +166,7 @@ func NewContext() {
 			Locale: Cfg.Section(secName).Key("LOCALE").MustString(secName),
 			Link:   Cfg.Section(secName).Key("LINK").MustString("/"),
 			Blank:  Cfg.Section(secName).Key("BLANK").MustBool(),
+			Enable: Cfg.Section(secName).Key("ENABLE").MustBool(true),
 		}
 	}
 

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,10 +1,12 @@
 <div class="ui container">
   <div class="ui large secondary inverted menu">
-  	{% for item in Navbar.Items %}
-      <a class="{% if item.Link == Link %}active{% endif %} item" href="{{item.Link}}" {% if item.Blank %}target="_blank"{% endif %}>
-        {% if item.Icon %}<i class="{{item.Icon}} icon"></i>{% endif %}
-        {{Tr(Lang, item.Locale)}}
-      </a>
+    {% for item in Navbar.Items %}
+      {% if item.Enable %}
+        <a class="{% if item.Link == Link %}active{% endif %} item" href="{{item.Link}}" {% if item.Blank %}target="_blank"{% endif %}>
+          {% if item.Icon %}<i class="{{item.Icon}} icon"></i>{% endif %}
+          {{Tr(Lang, item.Locale)}}
+        </a>
+      {% endif %}
     {% endfor %}
     <div class="right item">
       {% if Extension.EnableSearch %}

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,7 +1,7 @@
 <div class="ui container">
   <div class="ui large secondary inverted menu">
     {% for item in Navbar.Items %}
-      {% if item.Enable %}
+      {% if item.Enabled %}
         <a class="{% if item.Link == Link %}active{% endif %} item" href="{{item.Link}}" {% if item.Blank %}target="_blank"{% endif %}>
           {% if item.Icon %}<i class="{{item.Icon}} icon"></i>{% endif %}
           {{Tr(Lang, item.Locale)}}


### PR DESCRIPTION
I'd like a way to hide the github navbar item.  I tried removing it from my custom/app.ini but the item still appears on the navbar.

Example 1:
```ini
[navbar]
-: home
-: documentation
```

I think it behaves this way because the [navbar.github] section exists in bindata conf/app.ini and this must cause Cfg.Section("navbar").KeyString() to include the github link.

There may be a better way to fix this but i'm proposing to add an Enable setting to NavBarItem which is set to true by default.

Example 2:
```ini
[navbar.github]
ENABLE = false
```