### PR TITLE
support serving files in non-root path

### DIFF
--- a/cmd/web.go
+++ b/cmd/web.go
@@ -54,6 +54,7 @@ func runWeb(ctx *cli.Context) {
 	}
 	m.Use(macaron.Recovery())
 	m.Use(macaron.Statics(macaron.StaticOptions{
+		Prefix:      setting.Site.AppRoot,
 		SkipLogging: setting.ProdMode,
 	}, "custom/public", "public", models.HTMLRoot))
 	m.Use(i18n.I18n(i18n.Options{
@@ -69,13 +70,13 @@ func runWeb(ctx *cli.Context) {
 	}))
 	m.Use(context.Contexter())
 
-	m.Get("/", routes.Home)
-	m.Get(setting.Page.DocsBaseURL, routes.Docs)
-	m.Get(setting.Page.DocsBaseURL + "/images/*", routes.DocsStatic)
-	m.Get(setting.Page.DocsBaseURL + "/*", routes.Protect, routes.Docs)
-	m.Post("/hook", routes.Hook)
-	m.Get("/search", routes.Search)
-	m.Get("/*", routes.Pages)
+	m.Get(setting.Site.AppRoot+"/", routes.Home)
+	m.Get(setting.Site.AppRoot+setting.Page.DocsBaseURL, routes.Docs)
+	m.Get(setting.Site.AppRoot+setting.Page.DocsBaseURL+"/images/*", routes.DocsStatic)
+	m.Get(setting.Site.AppRoot+setting.Page.DocsBaseURL+"/*", routes.Protect, routes.Docs)
+	m.Post(setting.Site.AppRoot+"/hook", routes.Hook)
+	m.Get(setting.Site.AppRoot+"/search", routes.Search)
+	m.Get(setting.Site.AppRoot+"/*", routes.Pages)
 
 	listenAddr := fmt.Sprintf("%s:%d", setting.HTTPHost, setting.HTTPPort)
 	log.Info("%s Listen on %s", setting.Site.Name, listenAddr)

--- a/conf/app.ini
+++ b/conf/app.ini
@@ -8,6 +8,8 @@ NAME = Peach Server
 DESC = Peach is a web server for multi-language, real-time update and searchable documentation.
 USE_CDN = true
 URL = http://localhost:5555
+# If serving docs from somewhere other than root path
+APP_ROOT = 
 
 [page]
 HAS_LANDING_PAGE = true

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -53,10 +53,11 @@ var (
 	HTTPPort int
 
 	Site struct {
-		Name   string
-		Desc   string
-		UseCDN bool
-		URL    string
+		Name    string
+		Desc    string
+		UseCDN  bool
+		URL     string
+		AppRoot string
 	}
 
 	Page struct {
@@ -135,6 +136,7 @@ func NewContext() {
 	Site.Desc = sec.Key("DESC").String()
 	Site.UseCDN = sec.Key("USE_CDN").MustBool()
 	Site.URL = sec.Key("URL").String()
+	Site.AppRoot = sec.Key("APP_ROOT").MustString("")
 
 	sec = Cfg.Section("page")
 	Page.HasLandingPage = sec.Key("HAS_LANDING_PAGE").MustBool()

--- a/routes/docs.go
+++ b/routes/docs.go
@@ -45,7 +45,7 @@ func Docs(ctx *context.Context) {
 	}
 	ctx.Data["Toc"] = toc
 
-	nodeName := strings.TrimPrefix(strings.ToLower(strings.TrimSuffix(ctx.Req.URL.Path, ".html")), setting.Page.DocsBaseURL)
+	nodeName := strings.TrimPrefix(strings.ToLower(strings.TrimSuffix(ctx.Req.URL.Path, ".html")), setting.Site.AppRoot+setting.Page.DocsBaseURL)
 	node, isDefault := toc.GetDoc(nodeName)
 	if node == nil {
 		NotFound(ctx)
@@ -61,7 +61,7 @@ func Docs(ctx *context.Context) {
 		langVer = setting.Docs.Langs[0]
 	}
 	ctx.Data["Title"] = node.Title
-	ctx.Data["Content"] = fmt.Sprintf(`<script type="text/javascript" src="/%s/%s?=%d"></script>`, langVer, node.DocumentPath+".js", node.LastBuildTime)
+	ctx.Data["Content"] = fmt.Sprintf(`<script type="text/javascript" src="%s/%s/%s?=%d"></script>`, setting.Site.AppRoot, langVer, node.DocumentPath+".js", node.LastBuildTime)
 
 	renderEditPage(ctx, node.DocumentPath)
 	ctx.HTML(200, "docs")

--- a/routes/home.go
+++ b/routes/home.go
@@ -27,7 +27,7 @@ import (
 
 func Home(ctx *context.Context) {
 	if !setting.Page.HasLandingPage {
-		ctx.Redirect(setting.Page.DocsBaseURL)
+		ctx.Redirect(setting.Site.AppRoot + setting.Page.DocsBaseURL)
 		return
 	}
 
@@ -55,7 +55,7 @@ func Pages(ctx *context.Context) {
 			}
 
 			ctx.Data["Title"] = page.Title
-			ctx.Data["Content"] = fmt.Sprintf(`<script type="text/javascript" src="/%s/%s?=%d"></script>`, langVer, page.DocumentPath+".js", page.LastBuildTime)
+			ctx.Data["Content"] = fmt.Sprintf(`<script type="text/javascript" src="%s/%s/%s?=%d"></script>`, setting.Site.AppRoot, langVer, page.DocumentPath+".js", page.LastBuildTime)
 			ctx.Data["Pages"] = toc.Pages
 
 			renderEditPage(ctx, page.DocumentPath)

--- a/routes/protect.go
+++ b/routes/protect.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/peachdocs/peach/models"
 	"github.com/peachdocs/peach/pkg/context"
+	"github.com/peachdocs/peach/pkg/setting"
 )
 
 func authRequired(ctx *context.Context) {
@@ -51,7 +52,7 @@ func Protect(ctx *context.Context) {
 	}
 
 	// Check if resource is protected.
-	allows, yes := models.Protector.Resources[strings.TrimPrefix(ctx.Req.URL.Path, "/docs/")]
+	allows, yes := models.Protector.Resources[strings.TrimPrefix(ctx.Req.URL.Path, setting.Site.AppRoot+"/docs/")]
 	if !yes {
 		return
 	}

--- a/routes/search.go
+++ b/routes/search.go
@@ -30,7 +30,7 @@ func Search(ctx *context.Context) {
 
 	q := ctx.Query("q")
 	if len(q) == 0 {
-		ctx.Redirect(setting.Page.DocsBaseURL)
+		ctx.Redirect(setting.Site.AppRoot + setting.Page.DocsBaseURL)
 		return
 	}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,9 +4,9 @@
 		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
 		<meta name="description" content="{{Site.Desc}}" />
 
-		<link rel="shortcut icon" href="/img/favicon.ico" />
-		<link href="/css/semantic.min.css?v={{AppVer}}" rel="stylesheet" />
-		<link href="/css/peach.css?v={{AppVer}}" rel="stylesheet" />
+		<link rel="shortcut icon" href="{{Site.AppRoot}}/img/favicon.ico" />
+		<link href="{{Site.AppRoot}}/css/semantic.min.css?v={{AppVer}}" rel="stylesheet" />
+		<link href="{{Site.AppRoot}}/css/peach.css?v={{AppVer}}" rel="stylesheet" />
 
 		{% if Asset.CustomCSS %}
 			<link href="{{Asset.CustomCSS}}" rel="stylesheet" />
@@ -15,19 +15,19 @@
 		{% if Site.UseCDN %}
 			<script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
 		{% else %}
-			<script type="text/javascript" src="/js/jquery-1.11.3.min.js"></script>
+			<script type="text/javascript" src="{{Site.AppRoot}}/js/jquery-1.11.3.min.js"></script>
 		{% endif %}
 		
-		<script type="text/javascript" src="/js/semantic.min.js?v={{AppVer}}"></script>
-		<script type="text/javascript" src="/js/emojify-1.1.0.min.js"></script>
-		<script type="text/javascript" src="/js/peach.js?v={{AppVer}}"></script>
+		<script type="text/javascript" src="{{Site.AppRoot}}/js/semantic.min.js?v={{AppVer}}"></script>
+		<script type="text/javascript" src="{{Site.AppRoot}}/js/emojify-1.1.0.min.js"></script>
+		<script type="text/javascript" src="{{Site.AppRoot}}/js/peach.js?v={{AppVer}}"></script>
 
 		{% if Extension.HighlightJSCustomCSS %}
 			<link rel="stylesheet" href="{{Extension.HighlightJSCustomCSS}}">
 		{% else %}
-			<link rel="stylesheet" href="/css/highlight-9.12.0/default.css">
+			<link rel="stylesheet" href="{{Site.AppRoot}}/css/highlight-9.12.0/default.css">
 		{% endif %}
-		<script src="/js/highlight-9.12.0.pack.js"></script>
+		<script src="{{Site.AppRoot}}/js/highlight-9.12.0.pack.js"></script>
 
 		<title>{% block title %}{{Title}}{% endblock %}</title>
 	</head>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -11,7 +11,7 @@
       <div class="three wide column">
         <h4 class="ui inverted header">{{Tr(Lang, "footer.project")}}</h4>
         <div class="ui inverted link list">
-          <a class="item" href="/docs" >{{Tr(Lang, "footer.documentation")}}</a>
+          <a class="item" href="{{Site.AppRoot}}/docs" >{{Tr(Lang, "footer.documentation")}}</a>
           <a class="item" href="https://github.com/peachdocs/peach/issues">{{Tr(Lang, "footer.submit_issue")}}</a>
         </div>
       </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,7 +10,7 @@
 	      {{Tr(Lang, "home.title")}}
 	    </h1>
 	    <h2>{{Tr(Lang, "home.tag_line")}}</h2>
-	    <a class="ui huge primary button" href="{{Page.DocsBaseURL}}">{{Tr(Lang, "home.get_started")}} <i class="right arrow icon"></i></a>
+	    <a class="ui huge primary button" href="{{Site.AppRoot}}{{Page.DocsBaseURL}}">{{Tr(Lang, "home.get_started")}} <i class="right arrow icon"></i></a>
 	  </div>
 	</div>
 

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -1,14 +1,16 @@
 <div class="ui container">
   <div class="ui large secondary inverted menu">
-  	{% for item in Navbar.Items %}
-      <a class="{% if item.Link == Link %}active{% endif %} item" href="{{item.Link}}" {% if item.Blank %}target="_blank"{% endif %}>
-        {% if item.Icon %}<i class="{{item.Icon}} icon"></i>{% endif %}
-        {{Tr(Lang, item.Locale)}}
-      </a>
+    {% for item in Navbar.Items %}
+      {% if item.Enable %}
+        <a class="{% if item.Link == Link %}active{% endif %} item" href="{{item.Link}}" {% if item.Blank %}target="_blank"{% endif %}>
+          {% if item.Icon %}<i class="{{item.Icon}} icon"></i>{% endif %}
+          {{Tr(Lang, item.Locale)}}
+        </a>
+      {% endif %}
     {% endfor %}
     <div class="right item">
       {% if Extension.EnableSearch %}
-        <form action="/search">
+        <form action="{{Site.AppRoot}}/search">
           <div class="item">
             <div class="ui small input">
               <input name="q" value="{{Keyword}}" placeholder="{{Tr(Lang, "navbar.search")}}...">

--- a/templates/search.html
+++ b/templates/search.html
@@ -10,7 +10,7 @@
 				{% for result in Results %}
 					<div class="ui segment">
 						<div class="ui header">
-							<a href="{{Page.DocsBaseURL}}/{{result.Path}}">{{result.Title}}</a>
+							<a href="{{Site.AppRoot}}{{Page.DocsBaseURL}}/{{result.Path}}">{{result.Title}}</a>
 						</div>
 						<p>...{{result.Match}}...</p>
 					</div>


### PR DESCRIPTION
I'd like to host my peach docs instance from a non-root path of my webserver, for example; _example.com/peach_ instead of _peach.example.com_.

I would like to add the APP_ROOT key to the site section of app.ini.  This setting will prepend APP_ROOT to all routes and URLs served by peach itself and by the default template files.

It's possible to do some of this by rewriting the path when proxying a request but this only works if you can rewrite the application responses as well. 

app.ini for _example.com/peach_:
```ini
[site]
APP_ROOT = /peach
```